### PR TITLE
inputStl() functionality working and 100% tested

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NAME
 
-CAD::Mesh3D - Create and Manipulate 3D Vertices and Meshes and output for 3D printing
+CAD::Mesh3D - Create and Manipulate 3D Vertexes and Meshes and output for 3D printing
 
 # SYNOPSIS
 
@@ -8,29 +8,24 @@ CAD::Mesh3D - Create and Manipulate 3D Vertices and Meshes and output for 3D pri
     my $vect = createVertex();
     my $tri  = createFacet($v1, $v2, $v3);
     my $mesh = createMesh();
-    addToMesh($mesh, $tri);
-    push @$mesh, $tri;               # manual method of addToMesh()
+    $mesh->addToMesh($tri);
     ...
-    $mesh->output(STL => $filehandle_or_filename, $true_for_ascii_false_for_binary);
+    $mesh->output(STL => $filehandle_or_filename, $ascii_or_binary);
 
 # DESCRIPTION
 
-A framework to create and manipulate 3D vertices and meshes, suitable for generating STL files
+A framework to create and manipulate 3D vertexes and meshes, suitable for generating STL files
 (or other similar formats) for 3D printing.
 
 A **Mesh** is the container for the surface of the shape or object being generated.  The surface is broken down
-into locally-flat pieces known as **Facet**s.  Each Facet is a triangle made from exactly points, called
-**Vertex**es or vertices.  Each Vertex is made up of three x, y, and z **coordinate**s, which are just
-floating-point values to represent the position in 3D space.
+into locally-flat pieces known as **Facets**.  Each **Facet** is a triangle made from three points, called
+**Vertexes** (also spelled as vertices).  Each **Vertex** is made up of three x, y, and z **coordinates**, which
+are just floating-point values to represent the position in 3D space.
 
 # TODO
 
-- allow object-oriented notation
-
-        x cover mesh->output() notation
-        _ should I allow mesh->input?
-           - if so, does that mean that %$mesh = %{ input(STL=>$file) }?
-           - or does $mesh remain unchanged, returning a new, separate mesh object?
+- Add more math for **Vertexes** and **Facets**, as new functions are identified
+as being useful.
 
 # AUTHOR
 

--- a/lib/CAD/Mesh3D/STL.pm
+++ b/lib/CAD/Mesh3D/STL.pm
@@ -214,11 +214,12 @@ sub inputStl {
             };
             stat($file);    # this will cause the warning if it's in-memory
         }
-    }
-    $asc_or_bin ||= 'binary';      # 0 or '' or undefined defaults to binary
+    } elsif ( $asc_or_bin =~ /(asc(?:ii)?|bin(?:ary)?)/i ) {
+        # we found an explicit 'ascii/binary' indicator
+        unshift @pass_args, $asc_or_bin;
+    } # otherwise, ignore $asc_or_bin as unknown
 
-
-    my $stl = CAD::Format::STL->new()->load($file);       # CFS claims it take handle or name
+    my $stl = CAD::Format::STL->new()->load(@pass_args); # CFS claims it take handle or name
         # TODO: bug report <https://rt.cpan.org/Public/Dist/Display.html?Name=CAD-Format-STL>:
         #   examples show ->reader() and ->writer(), but that example code doesn't compile
     my @stlf = $stl->part()->facets();

--- a/lib/CAD/Mesh3D/STL.pm
+++ b/lib/CAD/Mesh3D/STL.pm
@@ -212,9 +212,8 @@ sub inputStl {
                         " ";
                 }
             };
-            stat($file);
+            stat($file);    # this will cause the warning if it's in-memory
         }
-
     }
     $asc_or_bin ||= 'binary';      # 0 or '' or undefined defaults to binary
 

--- a/lib/CAD/Mesh3D/STL.pm
+++ b/lib/CAD/Mesh3D/STL.pm
@@ -215,7 +215,8 @@ sub inputStl {
                     carp @_; # uncoverable statement
                 }
             };
-            stat($file);    # this will cause the warning if it's in-memory
+            my $size = (stat($file))[7];    # this will cause the warning if it's in-memory
+            carp "stat() on unopened filehandle" unless defined $size;  # force the warning on 5.16-5.20, which for some reason didn't warn...
         }
     } elsif ( $asc_or_bin =~ /(asc(?:ii)?|bin(?:ary)?)/i ) {
         # we found an explicit 'ascii/binary' indicator

--- a/lib/CAD/Mesh3D/STL.pm
+++ b/lib/CAD/Mesh3D/STL.pm
@@ -214,6 +214,8 @@ sub inputStl {
                         "\t\tinput(STL => \$in_mem_fh, \$asc_or_bin)\n",
                         "\twhere \$asc_or_bin is either 'ascii' or 'binary'\n";
                         " ";
+                } else {
+                    carp @_;
                 }
             };
             stat($file);    # this will cause the warning if it's in-memory

--- a/lib/CAD/Mesh3D/STL.pm
+++ b/lib/CAD/Mesh3D/STL.pm
@@ -13,19 +13,18 @@ CAD::Mesh3D::STL - Used by CAD::Mesh3D to provide the STL format-specific functi
 
 =head1 SYNOPSIS
 
- use CAD::Mesh3D qw(+STL :create :formats);       # enable CAD::Mesh3D::STL, and import the :create and :formats tags
- my $v1 = createVertex(...);
- ...
+ use CAD::Mesh3D qw(+STL :create :formats);
+ my $vect = createVertex();
  my $tri  = createFacet($v1, $v2, $v3);
  my $mesh = createMesh();
- addToMesh($mesh, $tri);
+ $mesh->addToMesh($tri);
  ...
- $mesh->output(STL => $filehandle_or_filename, $true_for_ascii_false_for_binary);
+ $mesh->output(STL => $filehandle_or_filename, $ascii_or_binary);
 
 =head1 DESCRIPTION
 
 This module is used by L<CAD::Mesh3D> to provide the STL format-specific functionality, including
-saving B<Mesh>es as STL files, or loading a B<Mesh>es from STL files.
+saving B<Meshes> as STL files, or loading a B<Meshes> from STL files.
 
 L<STL|https://en.wikipedia.org/wiki/STL_(file_format)> ("stereolithography") files are a CAD format used as inputs in the 3D printing process.
 
@@ -167,30 +166,37 @@ sub outputStl {
 
 =head3 inputStl
 
-NOT YET IMPLEMENTED
-
 To input your B<Mesh> from an STL file, you should use L<CAD::Mesh3D>'s C<input()> wrapper function,
 which is included in the C<:formats> import tag.
 
  use CAD::Mesh3D qw/+STL :formats/;
- my $mesh = input(STL => $file, $asc);
+ my $mesh = input(STL => $file, $mode);
+ my $mesh2= input(STL => $file);        # will determine ascii/binary based on file contents
 
 The wrapper will call the C<CAD::Mesh3D::STL::inputStl()> function internally, but makes it easy to
 keep your code compatible with other 3d-file formats.
 
 If you insist on calling the STL function directly, it is possible, but not recommended, to call
 
- my $mesh = CAD::Mesh3D::STL::inputStl($file, $asc);
+ my $mesh = CAD::Mesh3D::STL::inputStl($file, $mode);
 
 The C<$file> argument is either an already-opened filehandle, or the name of the file
 (if the full path is not specified, it will default to your script's directory),
 or "STDIN" to receive the input from the standard input handle.
 
-The C<$asc> argument determines whether to use STL's ASCII mode: a non-zero numeric value,
-or the case-insensitive text "ASCII" or "ASC" will select ASCII mode; a missing or undefined
-C<$asc> argument, or a zero value or empty string, or the case-insensitive text "BINARY"
-or "BIN" will select BINARY mode; if the argument contains a string other than those mentioned,
-S<C<inputStl()>> will cause the script to die.
+The C<$mode> argument determines whether to use STL's ASCII mode:
+The case-insensitive text "ASCII" or "ASC" will select ASCII mode.
+The case-insensitive text "BINARY" or "BIN" will select BINARY mode.
+If the argument contains a string other than those mentioned, S<C<inputStl()>> will cause
+the script to die.
+On a missing or undefined C<$mode> argument, or empty string, will cause C<input()> to try
+to determine if it's ASCII or BINARY; C<input()> will die if it cannot determine the file's
+mode automatically.
+
+Caveat: When using an in-memory filehandle, you must explicitly define the C<$mode> option,
+otherwise C<input()> will die.  (In-memory filehandles are not common. See L<open>, search for
+"in-memory file", to find a little more about them.  It is not likely you will require such
+a situation, but with explicit C<$mode>, they will work.)
 
 =cut
 
@@ -199,24 +205,20 @@ sub inputStl {
     my @pass_args = ($file);
     if( !defined($asc_or_bin) || ('' eq $asc_or_bin)) { # automatic
         # automatic won't work on in-memory files, for which stat() will give an "unopened filehandle" warning
+        #   unfortunately, perl v5.16 - v5.20 seem to _not_ give that warning.  Check definedness of $size, instead
+        #   (which actually simplifies the check, significantly)
         in_memory_check: {
-            local $SIG{__WARN__} = sub {
-                # uncoverable branch false
-                if( $_[0] =~ /\Qstat() on unopened filehandle\E/ ) {
-                    croak "\ninputStl($file): ERROR\n",
+            no warnings 'unopened';         # avoid printing the warning; just looking for the definedness of $size
+            my $size = (stat($file))[7];    # on perl v<5.16 and v>5.20, will warn; on all tested perl, will give $size=undef
+            croak "\ninputStl($file): ERROR\n",
                         "\tin-memory file handles are not allowed without explicit ASCII or BINARY setting\n",
                         "\tplease rewrite the call with an explicit\n",
                         "\t\tinputStl(\$in_mem_fh, \$asc_or_bin)\n",
                         "\tor\n",
                         "\t\tinput(STL => \$in_mem_fh, \$asc_or_bin)\n",
                         "\twhere \$asc_or_bin is either 'ascii' or 'binary'\n",
-                        " ";
-                } else {
-                    carp @_; # uncoverable statement
-                }
-            };
-            my $size = (stat($file))[7];    # this will cause the warning if it's in-memory
-            carp "stat() on unopened filehandle" unless defined $size;  # force the warning on 5.16-5.20, which for some reason didn't warn...
+                        " "
+                unless defined $size;
         }
     } elsif ( $asc_or_bin =~ /(asc(?:ii)?|bin(?:ary)?)/i ) {
         # we found an explicit 'ascii/binary' indicator
@@ -245,13 +247,34 @@ sub inputStl {
     return createMesh( @facets );
 }
 
-=head1 TODO
+=head1 SEE ALSO
 
 =over
 
-=item * implement inputSTL()
+=item * L<CAD::Format::STL> - This is the backend used by CAD::Mesh3D::STL, which handles them
+actual parsing and writing of the STL files.
 
 =back
+
+=head1 KNOWN ISSUES
+
+=head2 CAD::Format::STL binary Windows bug
+
+There is a L<known bug|https://rt.cpan.org/Public/Bug/Display.html?id=83595> in CAD::Format::STL v0.2.1,
+which on Windows systems will cause binary STL files which happen to have the 0x0D byte to corrupt the
+data on output or input.  Most binary STL files will work just fine; but there are a non-trivial number
+of floating-point values in the STL which include the 0x0D byte.  There is a test for this in the C<xt\>
+author-tests of the CAD-Mesh3D distribution.
+
+If your copy of CAD::Format::STL is affected by this bug, there is an easy patch, which you can manually
+add by editing your installed C<CAD\Format\STL.pm>: near line 423, after the error checking in
+C<sub _write_binary>, add the line C<binmode $fh;> as the fourth line of code in that sub.  Similarly,
+near line 348, add the line C<binmode $fh;> as the third line of code inside the C<sub _read_binary>.
+
+The author of CAD::Format::STL has been notified, both through the
+L<issue tracker|https://rt.cpan.org/Public/Bug/Display.html?id=83595>, and responding to requests to
+fix the bug.  Hopefully, when the author has time, a new version of CAD::Format::STL will be released
+with the bug fixed.  Until then, patching the module is the best workaround.
 
 =head1 AUTHOR
 

--- a/lib/CAD/Mesh3D/STL.pm
+++ b/lib/CAD/Mesh3D/STL.pm
@@ -194,6 +194,10 @@ S<C<inputStl()>> will cause the script to die.
 
 =cut
 
+# TODO: in sscce-memfh-intercept-warning.pl, confirmed it's safe to warn/carp/die/croak inside __WARN__ handler
+#   (see pervar %SIG => "The __DIE__ handler is explicitly disabled during the call, so that you can die from a __DIE__ handler. Similarly for __WARN__ .")
+#   so I can now make the __WARN__ handler pass thru other warnings
+
 sub inputStl {
     my ($file, $asc_or_bin) = @_;
     my @pass_args = ($file);

--- a/t/40-format.t
+++ b/t/40-format.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More tests => 23;
 use Test::Exception;
 
-use CAD::Mesh3D qw(+STL :all);
+use CAD::Mesh3D qw(:all);
 
 sub test_format {
     my $format = shift;
@@ -30,7 +30,8 @@ sub test_format {
 ##################################################
 # enableFormat() functional coverage tests
 ##################################################
-test_format( 'STL', 'CAD::Mesh3D::STL', input => qr/not yet debugged inputting from STL/ );
+enableFormat('STL');
+test_format( 'STL', 'CAD::Mesh3D::STL' );
 
 ##################################################
 # enableFormat(): missing input/output functions

--- a/t/40-format.t
+++ b/t/40-format.t
@@ -4,7 +4,7 @@ use warnings;
 use Test::More tests => 23;
 use Test::Exception;
 
-use CAD::Mesh3D qw(:all);
+use CAD::Mesh3D qw(:formats);
 
 sub test_format {
     my $format = shift;
@@ -29,12 +29,16 @@ sub test_format {
 
 ##################################################
 # enableFormat() functional coverage tests
+#   make sure that a format imported using enableFormat() will properly populate the
+#   Eanbled hash using _io_functions()
 ##################################################
 enableFormat('STL');
 test_format( 'STL', 'CAD::Mesh3D::STL' );
 
 ##################################################
 # enableFormat(): missing input/output functions
+#   mock up a couple of formats, each missing one
+#   "import" manually, rather than by enableFormat()
 ##################################################
 sub mockedFormat::MissingInput::_io_functions { output => sub { 'output' } }
 $INC{'mockedFormat/MissingInput.pm'} = 1;
@@ -50,6 +54,8 @@ is( input( MissingOutput => 'dne' ), 'input', 'input( MissingOutput => file) giv
 
 ##################################################
 # enableFormat(): error testing
+#   intentionally create error conditions to verify
+#   exception-throwing
 ##################################################
 throws_ok { enableFormat(); } qr/requires name of format/, 'Error Handling: enableFormat(missing format name)';
 throws_ok { enableFormat( 'DoesNotExist' ); } qr/could not import CAD::Mesh3D::DoesNotExist/, 'Error Handling: enableFormat(unavailable module selected)';

--- a/t/99-fault.t
+++ b/t/99-fault.t
@@ -15,9 +15,9 @@ throws_ok { createVertex(1,2); } qr/createVertex.*requires 3 coordinates; you su
 throws_ok { createVertex(1..4); } qr/createVertex.*requires 3 coordinates; you supplied 4/, 'Error Handling: createVertex(four args)';
 
 # createFacet(): wrong number of Vertexs
-throws_ok { createFacet(); } qr/createFacet.*requires 3 Vertices; you supplied 0/, 'Error Handling: createFacet(no args)';
-throws_ok { createFacet(1..2); } qr/createFacet.*requires 3 Vertices; you supplied 2/, 'Error Handling: createFacet(two args)';
-throws_ok { createFacet(1..4); } qr/createFacet.*requires 3 Vertices; you supplied 4/, 'Error Handling: createFacet(four args)';
+throws_ok { createFacet(); } qr/createFacet.*requires 3 Vertexes; you supplied 0/, 'Error Handling: createFacet(no args)';
+throws_ok { createFacet(1..2); } qr/createFacet.*requires 3 Vertexes; you supplied 2/, 'Error Handling: createFacet(two args)';
+throws_ok { createFacet(1..4); } qr/createFacet.*requires 3 Vertexes; you supplied 4/, 'Error Handling: createFacet(four args)';
 
 # createFacet(): invalid Vertex
 throws_ok { createFacet( undef, [0,0,0], [1,1,1]); } qr/createFacet.*each Vertex must be an array ref or equivalent object; you supplied a scalar"<undef>"/, 'Error Handling: createFacet(undef first  Vertex)';
@@ -37,15 +37,15 @@ throws_ok { createFacet( [0,0,0], [1,1,1], [1,2]); } qr/createFacet.*each Vertex
 throws_ok { createFacet( [0,0,0], [1,1,1], [1..4]); } qr/createFacet.*each Vertex requires 3 coordinates; you supplied 4/, 'Error Handling: createFacet(long  third  Vertex)';
 
 # createQuadrangleFacets(): wrong number of Vertexes
-throws_ok { createQuadrangleFacets(); } qr/createQuadrangleFacets.*requires 4 Vertices; you supplied 0/, 'Error Handling: createQuadrangleFacets(no args)';
-throws_ok { createQuadrangleFacets(1..3); } qr/createQuadrangleFacets.*requires 4 Vertices; you supplied 3/, 'Error Handling: createQuadrangleFacets(three args)';
-throws_ok { createQuadrangleFacets(1..5); } qr/createQuadrangleFacets.*requires 4 Vertices; you supplied 5/, 'Error Handling: createQuadrangleFacets(five args)';
+throws_ok { createQuadrangleFacets(); } qr/createQuadrangleFacets.*requires 4 Vertexes; you supplied 0/, 'Error Handling: createQuadrangleFacets(no args)';
+throws_ok { createQuadrangleFacets(1..3); } qr/createQuadrangleFacets.*requires 4 Vertexes; you supplied 3/, 'Error Handling: createQuadrangleFacets(three args)';
+throws_ok { createQuadrangleFacets(1..5); } qr/createQuadrangleFacets.*requires 4 Vertexes; you supplied 5/, 'Error Handling: createQuadrangleFacets(five args)';
 
 # createMesh(): invalid triangle
 throws_ok { createMesh( undef ); } qr/createMesh.*each triangle must be defined; this one was undef/, 'Error Handling: createMesh(undef triangle)';
-throws_ok { createMesh( [] ); } qr/createMesh.*each triangle requires 3 Vertices; you supplied 0/, 'Error Handling: createMesh(no Vertexs)';
-throws_ok { createMesh( [1..2] ); } qr/createMesh.*each triangle requires 3 Vertices; you supplied 2/, 'Error Handling: createMesh(two Vertexs)';
-throws_ok { createMesh( [1..4] ); } qr/createMesh.*each triangle requires 3 Vertices; you supplied 4/, 'Error Handling: createMesh(four Vertexs)';
+throws_ok { createMesh( [] ); } qr/createMesh.*each triangle requires 3 Vertexes; you supplied 0/, 'Error Handling: createMesh(no Vertexs)';
+throws_ok { createMesh( [1..2] ); } qr/createMesh.*each triangle requires 3 Vertexes; you supplied 2/, 'Error Handling: createMesh(two Vertexs)';
+throws_ok { createMesh( [1..4] ); } qr/createMesh.*each triangle requires 3 Vertexes; you supplied 4/, 'Error Handling: createMesh(four Vertexs)';
 throws_ok { createMesh( [undef, [0,0,0], [1,1,1]] ); } qr/createMesh.*each Vertex must be an array ref or equivalent object; you supplied a scalar"<undef>"/, 'Error Handling: createMesh(first  Vertex undef)';
 throws_ok { createMesh( [1, [0,0,0], [1,1,1]] ); } qr/createMesh.*each Vertex must be an array ref or equivalent object; you supplied a scalar"1"/, 'Error Handling: createMesh(first  Vertex scalar)';
 throws_ok { createMesh( [{}, [0,0,0], [1,1,1]] ); } qr/createMesh.*each Vertex must be an array ref or equivalent object; you supplied "HASH"/, 'Error Handling: createMesh(first  Vertex wrong ref)';
@@ -67,7 +67,7 @@ throws_ok { addToMesh( undef ); } qr/addToMesh.*: mesh must have already been cr
 throws_ok { addToMesh( $mesh, undef ); } qr/addToMesh.*: each triangle must be an array ref or equivalent object; you supplied a scalar "<undef>"/, 'Error Handling: addToMesh(mesh, undef): no triangle(s)';
 throws_ok { addToMesh( $mesh, 5 ); } qr/addToMesh.*: each triangle must be an array ref or equivalent object; you supplied a scalar "5"/, 'Error Handling: addToMesh(mesh, 5): scalar instead of triangle';
 throws_ok { addToMesh( $mesh, {} ); } qr/addToMesh.*: each triangle must be an array ref or equivalent object; you supplied "HASH"/, 'Error Handling: addToMesh(mesh, {}): triangle is wrong kind of reference';
-throws_ok { addToMesh( $mesh, [] ); } qr/addToMesh.*: each triangle requires 3 Vertices; you supplied 0/, 'Error Handling: addToMesh(mesh, []): empty triangle';
+throws_ok { addToMesh( $mesh, [] ); } qr/addToMesh.*: each triangle requires 3 Vertexes; you supplied 0/, 'Error Handling: addToMesh(mesh, []): empty triangle';
 throws_ok { addToMesh( $mesh, [$lft, $top, undef] ); } qr/addToMesh.*: each Vertex must be an array ref or equivalent object; you supplied a scalar "<undef>"/, 'Error Handling: addToMesh(mesh, [left, top, undef]): one vertex undef';
 throws_ok { addToMesh( $mesh, [$lft, 7, $mid] ); } qr/addToMesh.*: each Vertex must be an array ref or equivalent object; you supplied a scalar "7"/, 'Error Handling: addToMesh(mesh, [left, scalar, middle]): one vertex scalar';
 throws_ok { addToMesh( $mesh, [$lft, $top, {}] ); } qr/addToMesh.*: each Vertex must be an array ref or equivalent object; you supplied "HASH"/, 'Error Handling: addToMesh(mesh, [left, top, {}]): one vertex wrong reference type';

--- a/t/Format-STL.t
+++ b/t/Format-STL.t
@@ -207,6 +207,21 @@ foreach my $asc (undef, 0, qw(false binary bin true ascii asc), 1) {
 
 }
 
+# input(): debugging
+{
+    # input(): not yet defined
+#    throws_ok { my $mesh = input(STL => 'files/cube.stl') } qr/Sorry, CAD::Mesh3D::STL's developer has not yet debugged inputting from STL/, 'Error Handling: input() has not been implemented yet';
+#    throws_ok { my $mesh = CAD::Mesh3D::STL::inputStl('files/cube_binary.stl') } qr/\QCAD::Mesh3D::STL::inputStl(): not yet implemented, sorry.\E/, 'Error Handling: direct call to inputStl(), which has not been implemented yet';
+diag "\n"x 20;
+    my $memory = do { open my $fh, '<', 'files/cube.stl'; local $/; <$fh> };    # slurp
+    open my $memfh, '<', \$memory or die "in-memory handle failed: $!";
+    foreach my $file ( 'files/cube.stl', $memfh, 'files/cube_binary.stl') {
+        diag "file => $file\n";
+        my $mesh = input(STL => $file);
+        diag "\n"x 20;
+    }
+}
+
 ###### fault handling ######
 use Test::Exception;
 
@@ -218,11 +233,5 @@ throws_ok { output($mesh, STL => '/path/does/not/exist') } qr/output.*: cannot w
 
 # output(): non-recognized $ascii argument
 throws_ok { output($mesh, STL => \*STDERR, 'bad') } qr/output.*: unknown asc\/bin switch "bad"/, 'Error Handling: output(bad ascii switch)';
-
-# input(): not yet defined
-throws_ok { my $mesh = input(STL => \*STDIN) } qr/Sorry, CAD::Mesh3D::STL's developer has not yet debugged inputting from STL/, 'Error Handling: input() has not been implemented yet';
-
-# input(): not yet defined
-throws_ok { my $mesh = CAD::Mesh3D::STL::inputStl(\*STDIN) } qr/\QCAD::Mesh3D::STL::inputStl(): not yet implemented, sorry.\E/, 'Error Handling: direct call to inputStl(), which has not been implemented yet';
 
 done_testing();

--- a/t/STL-inputStl.t
+++ b/t/STL-inputStl.t
@@ -12,17 +12,9 @@ use CAD::Mesh3D qw(+STL :all);
 use Scalar::Util qw/openhandle/;
 my $memory = do { open my $fh, '<', 'files/cube.stl'; local $/; <$fh> };    # slurp
 open my $memfh, '<', \$memory or die "in-memory handle failed: $!";
-warn __LINE__, "\t", +(openhandle( $memfh ) ? 'filehandle open' : 'filehandle not available'), "\n";
-warn __LINE__, "\t", join($",stat $memfh),"\n";
-foreach my $file ( $memfh, 'files/cube.stl', 'files/cube_binary.stl') {
-    diag "file => $file\n";
-warn __LINE__, "\t", +(openhandle( $memfh ) ? 'filehandle open' : 'filehandle not available'), "\n";
-warn __LINE__, "\t", +(openhandle( $file ) ? 'filehandle open' : 'filehandle not available'), "\n"      if UNIVERSAL::isa($file, 'GLOB');
-warn __LINE__, "\t", join($,,stat $memfh),"\n";
-    my $mesh = input(STL => $file);
-warn __LINE__, "\t", +(openhandle( $memfh ) ? 'filehandle open' : 'filehandle not available'), "\n";
-warn __LINE__, "\t", +(openhandle( $file ) ? 'filehandle open' : 'filehandle not available'), "\n"      if UNIVERSAL::isa($file, 'GLOB');
-warn __LINE__, "\t", join($,,stat $memfh),"\n";
+foreach my $file ( $memfh, 'files/cube.stl', 'files/cube_binary.stl' ) {
+    # note "\n\nfile => $file\n";
+    my $mesh = ($file eq $memfh) ? input(STL => $file, 'ascii') : input(STL => $file);
     isa_ok( $mesh , 'CAD::Mesh3D');
     is( @$mesh , 12 , "input(STL=>$file): 12 facets" );
     my $f = $mesh->[8];
@@ -32,9 +24,8 @@ warn __LINE__, "\t", join($,,stat $memfh),"\n";
     foreach my $i ( 0 .. $#cmpv ) {
         is_deeply( $f->[$i], $cmpv[$i] , "compare facet.v[$i] to $cmpv[$i]");
     }
-    last;
-#    <STDIN>;
 }
+close $memfh;
 
 ###### fault handling ######
 use Test::Exception;

--- a/t/STL-inputStl.t
+++ b/t/STL-inputStl.t
@@ -1,0 +1,45 @@
+use 5.010;      # v5.8 equired for in-memory files; v5.10 required for named backreferences and // in the commented-note() calls
+use strict;
+use warnings;
+use Test::More tests => 3*7;
+
+use CAD::Mesh3D qw(+STL :all);
+
+# input(): debugging
+#    throws_ok { my $mesh = input(STL => 'files/cube.stl') } qr/Sorry, CAD::Mesh3D::STL's developer has not yet debugged inputting from STL/, 'Error Handling: input() has not been implemented yet';
+#    throws_ok { my $mesh = CAD::Mesh3D::STL::inputStl('files/cube_binary.stl') } qr/\QCAD::Mesh3D::STL::inputStl(): not yet implemented, sorry.\E/, 'Error Handling: direct call to inputStl(), which has not been implemented yet';
+
+use Scalar::Util qw/openhandle/;
+my $memory = do { open my $fh, '<', 'files/cube.stl'; local $/; <$fh> };    # slurp
+open my $memfh, '<', \$memory or die "in-memory handle failed: $!";
+warn __LINE__, "\t", +(openhandle( $memfh ) ? 'filehandle open' : 'filehandle not available'), "\n";
+warn __LINE__, "\t", join($",stat $memfh),"\n";
+foreach my $file ( $memfh, 'files/cube.stl', 'files/cube_binary.stl') {
+    diag "file => $file\n";
+warn __LINE__, "\t", +(openhandle( $memfh ) ? 'filehandle open' : 'filehandle not available'), "\n";
+warn __LINE__, "\t", +(openhandle( $file ) ? 'filehandle open' : 'filehandle not available'), "\n"      if UNIVERSAL::isa($file, 'GLOB');
+warn __LINE__, "\t", join($,,stat $memfh),"\n";
+    my $mesh = input(STL => $file);
+warn __LINE__, "\t", +(openhandle( $memfh ) ? 'filehandle open' : 'filehandle not available'), "\n";
+warn __LINE__, "\t", +(openhandle( $file ) ? 'filehandle open' : 'filehandle not available'), "\n"      if UNIVERSAL::isa($file, 'GLOB');
+warn __LINE__, "\t", join($,,stat $memfh),"\n";
+    isa_ok( $mesh , 'CAD::Mesh3D');
+    is( @$mesh , 12 , "input(STL=>$file): 12 facets" );
+    my $f = $mesh->[8];
+    isa_ok( $f , 'CAD::Mesh3D::Facet' );
+    is( @$f, 3 , "input(STL=>$file): 9th facet has 3 vertexes");
+    my @cmpv = (createVertex(1,0,0), createVertex(1,1,0), createVertex(1,1,1));
+    foreach my $i ( 0 .. $#cmpv ) {
+        is_deeply( $f->[$i], $cmpv[$i] , "compare facet.v[$i] to $cmpv[$i]");
+    }
+    last;
+#    <STDIN>;
+}
+
+###### fault handling ######
+use Test::Exception;
+
+# output(): missing fh
+#throws_ok { ... } qr/output.*: requires file handle or name/, 'Error Handling: ... TODO';
+
+done_testing();

--- a/t/STL-inputStl.t
+++ b/t/STL-inputStl.t
@@ -1,7 +1,7 @@
 use 5.010;      # v5.8 equired for in-memory files; v5.10 required for named backreferences and // in the commented-note() calls
 use strict;
 use warnings;
-use Test::More tests => 3*7;
+use Test::More tests => 3*7 + 3 + 1;
 
 use CAD::Mesh3D qw(+STL :all);
 
@@ -9,7 +9,6 @@ use CAD::Mesh3D qw(+STL :all);
 #    throws_ok { my $mesh = input(STL => 'files/cube.stl') } qr/Sorry, CAD::Mesh3D::STL's developer has not yet debugged inputting from STL/, 'Error Handling: input() has not been implemented yet';
 #    throws_ok { my $mesh = CAD::Mesh3D::STL::inputStl('files/cube_binary.stl') } qr/\QCAD::Mesh3D::STL::inputStl(): not yet implemented, sorry.\E/, 'Error Handling: direct call to inputStl(), which has not been implemented yet';
 
-use Scalar::Util qw/openhandle/;
 my $memory = do { open my $fh, '<', 'files/cube.stl'; local $/; <$fh> };    # slurp
 open my $memfh, '<', \$memory or die "in-memory handle failed: $!";
 foreach my $file ( $memfh, 'files/cube.stl', 'files/cube_binary.stl' ) {
@@ -30,7 +29,27 @@ close $memfh;
 ###### fault handling ######
 use Test::Exception;
 
-# output(): missing fh
-#throws_ok { ... } qr/output.*: requires file handle or name/, 'Error Handling: ... TODO';
+throws_ok {
+    open my $memfh, '<', \$memory or die "in-memory handle failed: $!";
+    input(STL => $memfh);
+    close $memfh;
+} qr/\Qin-memory file handles are not allowed without explicit ASCII or BINARY setting\E/, 'Error Handling: in-memory filehandle without explicit mode';
+
+throws_ok {
+    open my $memfh, '<', \$memory or die "in-memory handle failed: $!";
+    input(STL => $memfh, '');
+    close $memfh;
+} qr/\Qin-memory file handles are not allowed without explicit ASCII or BINARY setting\E/, 'Error Handling: in-memory filehandle with mode as empty string ("")';
+
+throws_ok {
+    input(STL => 'files/cube.stl', 'mode_does_not_exist');
+} qr/\QERROR: unknown mode 'mode_does_not_exist'\E/, 'Error Handling: unknown mode';
+
+
+SKIP: {
+    my $tname = 'Error Handling: non-captured warnings in __WARN__';
+    skip "$tname: `uncoverable branch false` and `uncoverable statement`", 1;
+    ok(1, $tname);
+}
 
 done_testing();

--- a/t/STL-outputStl.t
+++ b/t/STL-outputStl.t
@@ -1,7 +1,7 @@
 use 5.010;      # v5.8 equired for in-memory files; v5.10 required for named backreferences and // in the commented-note() calls
 use strict;
 use warnings;
-use Test::More tests => 5 + 5*28 + 3 + 5;
+use Test::More tests => 5 + 5*28 + 3 + 3;
 
 use CAD::Mesh3D qw(+STL :all);
 
@@ -205,21 +205,6 @@ foreach my $asc (undef, 0, qw(false binary bin true ascii asc), 1) {
     like( $slurp1, $expected_ubin,  sprintf 'mesh->output(STL => "%s", binary): binary file matches', $f1 );
     test_ascii( $slurp2, $exp_ascii_aref, sprintf 'mesh->output(STL => "%s", ascii)', $f2 );
 
-}
-
-# input(): debugging
-{
-    # input(): not yet defined
-#    throws_ok { my $mesh = input(STL => 'files/cube.stl') } qr/Sorry, CAD::Mesh3D::STL's developer has not yet debugged inputting from STL/, 'Error Handling: input() has not been implemented yet';
-#    throws_ok { my $mesh = CAD::Mesh3D::STL::inputStl('files/cube_binary.stl') } qr/\QCAD::Mesh3D::STL::inputStl(): not yet implemented, sorry.\E/, 'Error Handling: direct call to inputStl(), which has not been implemented yet';
-diag "\n"x 20;
-    my $memory = do { open my $fh, '<', 'files/cube.stl'; local $/; <$fh> };    # slurp
-    open my $memfh, '<', \$memory or die "in-memory handle failed: $!";
-    foreach my $file ( 'files/cube.stl', $memfh, 'files/cube_binary.stl') {
-        diag "file => $file\n";
-        my $mesh = input(STL => $file);
-        diag "\n"x 20;
-    }
 }
 
 ###### fault handling ######


### PR DESCRIPTION
added and debugged inputStl().  reached 100% coverage.

Had to debug an in-memory filehandle issue which caused failures on 5.16-5.20, but not other perl versions, so chose a second method to avoid the CAD::Format::STL stat/seek warning and error, but it's all working now.